### PR TITLE
Fixed lint errors

### DIFF
--- a/.changeset/free-brooms-help.md
+++ b/.changeset/free-brooms-help.md
@@ -1,0 +1,5 @@
+---
+"ember-codemod-rename-test-modules": minor
+---
+
+Fixed lint errors

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,10 +13,4 @@ export default [
     ],
   },
   ...baseConfiguration,
-  {
-    files: ['**/*.ts'],
-    rules: {
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-    },
-  },
 ];

--- a/src/utils/rename-tests/rename-module.ts
+++ b/src/utils/rename-tests/rename-module.ts
@@ -11,24 +11,30 @@ export function renameModule(file: string, data: Data): string {
   const ast = traverse(file, {
     visitCallExpression(node) {
       if (
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.callee.type !== 'Identifier' ||
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.callee.name !== 'module'
       ) {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (node.value.arguments.length !== 2) {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       switch (node.value.arguments[0].type) {
         case 'Literal': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           node.value.arguments[0] = AST.builders.literal(data.moduleName);
 
           break;
         }
 
         case 'StringLiteral': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           node.value.arguments[0] = AST.builders.stringLiteral(data.moduleName);
 
           break;

--- a/src/utils/rename-tests/rename-module.ts
+++ b/src/utils/rename-tests/rename-module.ts
@@ -9,34 +9,26 @@ export function renameModule(file: string, data: Data): string {
   const traverse = AST.traverse(data.isTypeScript);
 
   const ast = traverse(file, {
-    visitCallExpression(node) {
+    visitCallExpression(path) {
       if (
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.callee.type !== 'Identifier' ||
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.callee.name !== 'module'
+        path.node.callee.type !== 'Identifier' ||
+        path.node.callee.name !== 'module'
       ) {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (node.value.arguments.length !== 2) {
+      if (path.node.arguments.length !== 2) {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      switch (node.value.arguments[0].type) {
+      switch (path.node.arguments[0]!.type) {
         case 'Literal': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          node.value.arguments[0] = AST.builders.literal(data.moduleName);
-
+          path.node.arguments[0] = AST.builders.literal(data.moduleName);
           break;
         }
 
         case 'StringLiteral': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          node.value.arguments[0] = AST.builders.stringLiteral(data.moduleName);
-
+          path.node.arguments[0] = AST.builders.stringLiteral(data.moduleName);
           break;
         }
       }


### PR DESCRIPTION
## Background

Incorrect use of `recast` had led to unnecessary type errors. In general, `node.value` should have read `path.node` instead.
